### PR TITLE
Minor fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -211,9 +211,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "11.10.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.5.tgz",
-      "integrity": "sha512-DuIRlQbX4K+d5I+GMnv+UfnGh+ist0RdlvOp+JZ7ePJ6KQONCFQv/gKYSU1ZzbVdFSUCKZOltjmpFAGGv5MdYA==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.0.tgz",
+      "integrity": "sha512-D5Rt+HXgEywr3RQJcGlZUCTCx1qVbCZpVk3/tOOA6spLNZdGm8BU+zRgdRYDoF1pO3RuXLxADzMrF903JlQXqg==",
       "dev": true
     },
     "@types/stack-utils": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ export class PokeAPI {
     return axios
       .get<IAPIResourceList | INamedAPIResourceList>(url)
       .then((value: AxiosResponse<IAPIResourceList | INamedAPIResourceList>) => {
-        if (this._listIsNamed(value.data)) {
+        if (this._isListNamed(value.data)) {
           return value.data as INamedAPIResourceList;
         } else {
           return value.data as IAPIResourceList;
@@ -77,15 +77,15 @@ export class PokeAPI {
     return url.href;
   }
 
-  protected _isNumber(value: any): value is number {
-    return typeof value === 'number';
-  }
-
-  protected _listIsNamed(list: IAPIResourceList | INamedAPIResourceList): list is INamedAPIResourceList {
+  protected _isListNamed(list: IAPIResourceList | INamedAPIResourceList): list is INamedAPIResourceList {
     if (list.results.length > 0) {
       return (list as INamedAPIResourceList).results[0].name !== undefined;
     } else {
       return false;
     }
+  }
+
+  protected _isNumber(value: any): value is number {
+    return typeof value === 'number';
   }
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -53,20 +53,6 @@ describe('internal methods', (): void => {
     });
   });
 
-  describe('_isNumber', (): void => {
-    it('returns true if value is a number', (): void => {
-      const output: boolean = pokeapi.isNumber(0);
-
-      expect(output).to.equal(true);
-    });
-
-    it('returns false if value is not a number', (): void => {
-      const output: boolean = pokeapi.isNumber('hello');
-
-      expect(output).to.equal(false);
-    });
-  });
-
   describe('_isListNamed', (): void => {
     it('returns true if list is named', (): void => {
       const list: INamedAPIResourceList = {
@@ -112,6 +98,20 @@ describe('internal methods', (): void => {
       };
 
       const output: boolean = pokeapi.isListNamed(list);
+
+      expect(output).to.equal(false);
+    });
+  });
+
+  describe('_isNumber', (): void => {
+    it('returns true if value is a number', (): void => {
+      const output: boolean = pokeapi.isNumber(0);
+
+      expect(output).to.equal(true);
+    });
+
+    it('returns false if value is not a number', (): void => {
+      const output: boolean = pokeapi.isNumber('hello');
 
       expect(output).to.equal(false);
     });

--- a/test/index.ts
+++ b/test/index.ts
@@ -67,7 +67,7 @@ describe('internal methods', (): void => {
     });
   });
 
-  describe('_listIsNamed', (): void => {
+  describe('_isListNamed', (): void => {
     it('returns true if list is named', (): void => {
       const list: INamedAPIResourceList = {
         count: 1,
@@ -81,7 +81,7 @@ describe('internal methods', (): void => {
         ],
       };
 
-      const output: boolean = pokeapi.listIsNamed(list);
+      const output: boolean = pokeapi.isListNamed(list);
 
       expect(output).to.equal(true);
     });
@@ -98,7 +98,7 @@ describe('internal methods', (): void => {
         ],
       };
 
-      const output: boolean = pokeapi.listIsNamed(list);
+      const output: boolean = pokeapi.isListNamed(list);
 
       expect(output).to.equal(false);
     });
@@ -111,7 +111,7 @@ describe('internal methods', (): void => {
         results: [],
       };
 
-      const output: boolean = pokeapi.listIsNamed(list);
+      const output: boolean = pokeapi.isListNamed(list);
 
       expect(output).to.equal(false);
     });

--- a/test/support/endpoint-runner.ts
+++ b/test/support/endpoint-runner.ts
@@ -47,7 +47,7 @@ export function endpointRunner<T extends IPokeAPIResource | INamedPokeAPIResourc
           expect(output.name).to.equal(list.results[randomIndex].name);
         }
 
-        itemTests(output as any); // TODO: Remove 'any' check after 'get' method is fully populated with TPokeAPIEndpoint names
+        itemTests(output);
       } else {
         throw new Error('list not found');
       }
@@ -66,7 +66,7 @@ export function endpointRunner<T extends IPokeAPIResource | INamedPokeAPIResourc
           expect(output.id).to.equal(id);
           expect(output.name).to.equal(list.results[randomIndex].name);
 
-          itemTests(output as any); // TODO: Remove 'any' check after 'get' method is fully populated with TPokeAPIEndpoint names
+          itemTests(output);
         } else {
           this.skip();
         }

--- a/test/support/endpoint-runner.ts
+++ b/test/support/endpoint-runner.ts
@@ -26,7 +26,7 @@ export function endpointRunner<T extends IPokeAPIResource | INamedPokeAPIResourc
       expect(list.next).to.satisfy(isStringOrNull);
       expect(list.previous).to.satisfy(isStringOrNull);
 
-      if (pokeapi.listIsNamed(list)) {
+      if (pokeapi.isListNamed(list)) {
         expect(list.results[0].name).to.be.a('string');
       }
 
@@ -43,7 +43,7 @@ export function endpointRunner<T extends IPokeAPIResource | INamedPokeAPIResourc
 
         expect(output.id).to.equal(id);
 
-        if (pokeapi.listIsNamed(list)) {
+        if (pokeapi.isListNamed(list)) {
           expect(output.name).to.equal(list.results[randomIndex].name);
         }
 
@@ -53,17 +53,17 @@ export function endpointRunner<T extends IPokeAPIResource | INamedPokeAPIResourc
 
     // TODO: Figure out how to cancel this test entirely if the name property is not applicable
     it(`gets a ${endpoint} by name`, async (): Promise<void> => {
-      if (list && pokeapi.listIsNamed(list)) {
+      if (list && pokeapi.isListNamed(list)) {
         const randomIndex: number = Math.floor(Math.random() * (Math.floor(list.count - 1) + 1));
         const result: IAPIResource | INamedAPIResource = list.results[randomIndex];
         const urlParts: string[] = result.url.split('/');
         const id: number = Number(urlParts[urlParts.length - 2]);
-        const name: string | null = pokeapi.listIsNamed(list) ? (result as INamedAPIResource).name : '';
+        const name: string | null = pokeapi.isListNamed(list) ? (result as INamedAPIResource).name : '';
         const output: any = await pokeapi.get(endpoint as any, name); // TODO: Remove 'any' check after 'get' method is fully populated with TPokeAPIEndpoint names
 
         expect(output.id).to.equal(id);
 
-        if (pokeapi.listIsNamed(list)) {
+        if (pokeapi.isListNamed(list)) {
           expect(output.name).to.equal(list.results[randomIndex].name);
         }
 

--- a/test/support/endpoint-runner.ts
+++ b/test/support/endpoint-runner.ts
@@ -48,24 +48,30 @@ export function endpointRunner<T extends IPokeAPIResource | INamedPokeAPIResourc
         }
 
         itemTests(output as any); // TODO: Remove 'any' check after 'get' method is fully populated with TPokeAPIEndpoint names
+      } else {
+        throw new Error('list not found');
       }
     });
 
     it(`gets a ${endpoint} by name`, async function(): Promise<void> {
-      if (list && pokeapi.isListNamed(list)) {
-        const randomIndex: number = Math.floor(Math.random() * (Math.floor(list.count - 1) + 1));
-        const result: IAPIResource | INamedAPIResource = list.results[randomIndex];
-        const urlParts: string[] = result.url.split('/');
-        const id: number = Number(urlParts[urlParts.length - 2]);
-        const name: string | null = pokeapi.isListNamed(list) ? (result as INamedAPIResource).name : '';
-        const output: any = await pokeapi.get(endpoint as any, name); // TODO: Remove 'any' check after 'get' method is fully populated with TPokeAPIEndpoint names
+      if (list) {
+        if (pokeapi.isListNamed(list)) {
+          const randomIndex: number = Math.floor(Math.random() * (Math.floor(list.count - 1) + 1));
+          const result: IAPIResource | INamedAPIResource = list.results[randomIndex];
+          const urlParts: string[] = result.url.split('/');
+          const id: number = Number(urlParts[urlParts.length - 2]);
+          const name: string | null = pokeapi.isListNamed(list) ? (result as INamedAPIResource).name : '';
+          const output: any = await pokeapi.get(endpoint as any, name); // TODO: Remove 'any' check after 'get' method is fully populated with TPokeAPIEndpoint names
 
-        expect(output.id).to.equal(id);
-        expect(output.name).to.equal(list.results[randomIndex].name);
+          expect(output.id).to.equal(id);
+          expect(output.name).to.equal(list.results[randomIndex].name);
 
-        itemTests(output as any); // TODO: Remove 'any' check after 'get' method is fully populated with TPokeAPIEndpoint names
+          itemTests(output as any); // TODO: Remove 'any' check after 'get' method is fully populated with TPokeAPIEndpoint names
+        } else {
+          this.skip();
+        }
       } else {
-        this.skip();
+        throw new Error('list not found');
       }
     });
   });

--- a/test/support/endpoint-runner.ts
+++ b/test/support/endpoint-runner.ts
@@ -62,10 +62,7 @@ export function endpointRunner<T extends IPokeAPIResource | INamedPokeAPIResourc
         const output: any = await pokeapi.get(endpoint as any, name); // TODO: Remove 'any' check after 'get' method is fully populated with TPokeAPIEndpoint names
 
         expect(output.id).to.equal(id);
-
-        if (pokeapi.isListNamed(list)) {
-          expect(output.name).to.equal(list.results[randomIndex].name);
-        }
+        expect(output.name).to.equal(list.results[randomIndex].name);
 
         itemTests(output as any); // TODO: Remove 'any' check after 'get' method is fully populated with TPokeAPIEndpoint names
       }

--- a/test/support/endpoint-runner.ts
+++ b/test/support/endpoint-runner.ts
@@ -51,8 +51,7 @@ export function endpointRunner<T extends IPokeAPIResource | INamedPokeAPIResourc
       }
     });
 
-    // TODO: Figure out how to cancel this test entirely if the name property is not applicable
-    it(`gets a ${endpoint} by name`, async (): Promise<void> => {
+    it(`gets a ${endpoint} by name`, async function(): Promise<void> {
       if (list && pokeapi.isListNamed(list)) {
         const randomIndex: number = Math.floor(Math.random() * (Math.floor(list.count - 1) + 1));
         const result: IAPIResource | INamedAPIResource = list.results[randomIndex];
@@ -65,6 +64,8 @@ export function endpointRunner<T extends IPokeAPIResource | INamedPokeAPIResourc
         expect(output.name).to.equal(list.results[randomIndex].name);
 
         itemTests(output as any); // TODO: Remove 'any' check after 'get' method is fully populated with TPokeAPIEndpoint names
+      } else {
+        this.skip();
       }
     });
   });

--- a/test/support/pokeapi-public.ts
+++ b/test/support/pokeapi-public.ts
@@ -13,11 +13,11 @@ export class PokeAPIPublic extends PokeAPI {
     return this._constructUrl(endpoint, filter);
   }
 
-  public isNumber(value: any): value is number {
-    return this._isNumber(value);
+  public isListNamed(list: IAPIResourceList | INamedAPIResourceList): list is INamedAPIResourceList {
+    return this._isListNamed(list);
   }
 
-  public listIsNamed(list: IAPIResourceList | INamedAPIResourceList): list is INamedAPIResourceList {
-    return this._listIsNamed(list);
+  public isNumber(value: any): value is number {
+    return this._isNumber(value);
   }
 }

--- a/test/support/type-guards.ts
+++ b/test/support/type-guards.ts
@@ -2,7 +2,7 @@ import { IBerryFlavorMap, IContestName, IEffect, IFlavorBerryMap, IFlavorText, I
 
 // BerryFlavorMap
 function isBerryFlavorMap(resource: IBerryFlavorMap): resource is IBerryFlavorMap {
-  return isNamedAPIResource(resource.flavor) && typeof resource.potency === 'number';
+  return isNamedAPIResource(resource.flavor) && _isNumber(resource.potency);
 }
 
 export function isBerryFlavorMapArray(resource: IBerryFlavorMap[]): resource is IBerryFlavorMap[] {
@@ -11,7 +11,7 @@ export function isBerryFlavorMapArray(resource: IBerryFlavorMap[]): resource is 
 
 // FlavorBerryMap
 function isFlavorBerryMap(resource: IFlavorBerryMap): resource is IFlavorBerryMap {
-  return typeof resource.potency === 'number' && isNamedAPIResource(resource.berry);
+  return _isNumber(resource.potency) && isNamedAPIResource(resource.berry);
 }
 
 export function isFlavorBerryMapArray(resource: IFlavorBerryMap[]): resource is IFlavorBerryMap[] {
@@ -20,7 +20,7 @@ export function isFlavorBerryMapArray(resource: IFlavorBerryMap[]): resource is 
 
 // ContestName
 function isContestName(resource: IContestName): resource is IContestName {
-  return typeof resource.color === 'string' && isNamedAPIResource(resource.language) && typeof resource.name === 'string';
+  return _isString(resource.color) && isNamedAPIResource(resource.language) && _isString(resource.name);
 }
 
 export function isContestNameArray(resource: IContestName[]): resource is IContestName[] {
@@ -29,7 +29,7 @@ export function isContestNameArray(resource: IContestName[]): resource is IConte
 
 // Effect
 function isEffect(resource: IEffect): resource is IEffect {
-  return typeof resource.effect === 'string' && isNamedAPIResource(resource.language);
+  return _isString(resource.effect) && isNamedAPIResource(resource.language);
 }
 
 export function isEffectArray(resource: IEffect[]): resource is IEffect[] {
@@ -38,7 +38,7 @@ export function isEffectArray(resource: IEffect[]): resource is IEffect[] {
 
 // FlavorText
 function isFlavorText(resource: IFlavorText): resource is IFlavorText {
-  return typeof resource.flavor_text === 'string' && isNamedAPIResource(resource.language);
+  return _isString(resource.flavor_text) && isNamedAPIResource(resource.language);
 }
 
 export function isFlavorTextArray(resource: IFlavorText[]): resource is IFlavorText[] {
@@ -47,7 +47,7 @@ export function isFlavorTextArray(resource: IFlavorText[]): resource is IFlavorT
 
 // Name
 function isName(resource: IName): resource is IName {
-  return typeof resource.name === 'string' && isNamedAPIResource(resource.language);
+  return _isString(resource.name) && isNamedAPIResource(resource.language);
 }
 
 export function isNameArray(resource: IName[]): resource is IName[] {
@@ -56,7 +56,7 @@ export function isNameArray(resource: IName[]): resource is IName[] {
 
 // NamedAPIResource
 export function isNamedAPIResource(resource: INamedAPIResource): resource is INamedAPIResource {
-  return typeof resource.name === 'string' && typeof resource.url === 'string';
+  return _isString(resource.name) && _isString(resource.url);
 }
 
 export function isNamedAPIResourceArray(resource: INamedAPIResource[]): resource is INamedAPIResource[] {
@@ -72,15 +72,20 @@ function _isNull(value: any): value is null {
   return value === null;
 }
 
+function _isNumber(value: number): value is number {
+  return typeof value === 'number';
+}
+
 function _isString(value: string): value is string {
   return typeof value === 'string';
 }
 
-function _isResourceArray<T extends any>(resource: T[], resourceCheckMethod: (internalResource: T) => boolean): boolean {
-  const isArray: boolean = Array.isArray(resource);
-  const contentsCheck: boolean = resource.every((value: T) => {
-    return resourceCheckMethod(value);
-  });
-
-  return isArray && contentsCheck;
+function _isResourceArray<T extends any>(resource: T[], resourceCheckMethod: (internalResource: T) => boolean): resource is T[] {
+  if (Array.isArray(resource)) {
+    return resource.every((value: T) => {
+      return resourceCheckMethod(value);
+    });
+  } else {
+    return false;
+  }
 }


### PR DESCRIPTION
* index: Rename _listIsNamed to _isListNamed
* index: Remove redundant isListNamed check
* endpoint-runner: Skip name test for endpoints that do not have names
* endpoint-runner: Throw errors during tests if list dependency is not found
* type-guards: Using _isString where applicable
* type-guards: Added _isNumber to centralize it's type guard
* type-guards: Made _isResourceArray a real guard method
* package-lock.json: Updated